### PR TITLE
test(client): extract helper functions in test_client_send_p2p

### DIFF
--- a/crates/client/tests/test_client_send_p2p.rs
+++ b/crates/client/tests/test_client_send_p2p.rs
@@ -74,6 +74,110 @@ macro_rules! assert_event {
     };
 }
 
+/// Helper function to set up identity and wait for confirmation events
+fn setup_identity(
+    name: &str,
+    ui_tx: &async_channel::Sender<UiCommand>,
+    ui_rx: &async_channel::Receiver<UiEvent>,
+) -> UserIdentity {
+    let iden = UserIdentity::create(name).unwrap();
+
+    ui_tx
+        .send_blocking(UiCommand::SetIdentity(Some(iden.clone().into())))
+        .unwrap();
+    // NOTE: set identity currently causes two events, the direct response and that the working copy was updated
+    assert_event!(
+        &ui_rx.recv_blocking().unwrap(),
+        UiEvent::SetKnownIdentities(_)
+    );
+    assert_event!(&ui_rx.recv_blocking().unwrap(), UiEvent::IdentitySet(_));
+
+    iden
+}
+
+/// Helper function to establish trust with a contact
+fn trust_contact(
+    cid: &sremp_core::identity::ContactId,
+    ui_tx: &async_channel::Sender<UiCommand>,
+) {
+    ui_tx
+        .send_blocking(UiCommand::TrustContact(
+            cid.clone(),
+            sremp_core::identity::Trust::Trusted,
+        ))
+        .unwrap();
+}
+
+/// Helper function to start and select a chat
+fn setup_chat(
+    cid: &sremp_core::identity::ContactId,
+    ui_tx: &async_channel::Sender<UiCommand>,
+    ui_rx: &async_channel::Receiver<UiEvent>,
+) {
+    info!("starting chat");
+    ui_tx
+        .send_blocking(UiCommand::StartChat(cid.clone()))
+        .unwrap();
+    assert_event!(&ui_rx.recv_blocking().unwrap(), UiEvent::LoadedChats(_));
+
+    info!("selecting chat");
+    ui_tx
+        .send_blocking(UiCommand::SelectChat(cid.clone()))
+        .unwrap();
+    assert_event!(&ui_rx.recv_blocking().unwrap(), UiEvent::OpenChat(_));
+}
+
+/// Helper function to send a message and wait for confirmation
+fn send_message(
+    cid: &sremp_core::identity::ContactId,
+    msg: SharedMessage,
+    ui_tx: &async_channel::Sender<UiCommand>,
+    ui_rx: &async_channel::Receiver<UiEvent>,
+) {
+    info!("sending message");
+    ui_tx
+        .send_blocking(UiCommand::SendMessage(cid.clone(), msg))
+        .unwrap();
+    assert_event!(
+        &ui_rx.recv_blocking().unwrap(),
+        UiEvent::MessageSent(_, _, _)
+    );
+}
+
+/// Helper function to disconnect and wait for confirmation
+fn disconnect(
+    remote_sock: SocketAddr,
+    ui_tx: &async_channel::Sender<UiCommand>,
+    ui_rx: &async_channel::Receiver<UiEvent>,
+) {
+    ui_tx
+        .send_blocking(UiCommand::Disconnect(remote_sock))
+        .unwrap();
+    assert_event!(
+        &ui_rx.recv_blocking().unwrap(),
+        UiEvent::ConnectionLost(_, _)
+    );
+}
+
+/// Helper function to wait for connection and get the contact ID
+fn wait_for_connection(
+    ui_rx: &async_channel::Receiver<UiEvent>,
+) -> (SocketAddr, sremp_core::identity::ContactId) {
+    info!("Waiting for connection established event");
+    assert_event!(
+        &ui_rx.recv_blocking().unwrap(),
+        UiEvent::SetKnownIdentities(_) // new identity from peer
+    );
+    let evt = ui_rx.recv_blocking().unwrap();
+    assert_event!(&evt, UiEvent::ConnectionEstablished(_, _));
+
+    if let UiEvent::ConnectionEstablished(remote_sock, cid) = evt {
+        (remote_sock, cid)
+    } else {
+        panic!("Expected ConnectionEstablished event")
+    }
+}
+
 // NOTE: This is the first time I'm doing automated testing for client functionality with fork().
 // The idea is that i have two processes that run my test code to talk over a loopback socket, but
 // i'm not sure if that actually works for tests like this. I guess i can call this an integration
@@ -91,17 +195,7 @@ fn test_client_send_p2p() {
     match role {
         Fork::Parent(_) => {
             setup_logging(Some(" | P\n"));
-            let iden = UserIdentity::create("parent").unwrap();
-
-            ui_tx
-                .send_blocking(UiCommand::SetIdentity(Some(iden.clone().into())))
-                .unwrap();
-            // NOTE: set identity currently causes two events, the direct response and that the working copy was updated
-            assert_event!(
-                &ui_rx.recv_blocking().unwrap(),
-                UiEvent::SetKnownIdentities(_)
-            );
-            assert_event!(&ui_rx.recv_blocking().unwrap(), UiEvent::IdentitySet(_));
+            let iden = setup_identity("parent", &ui_tx, &ui_rx);
 
             ui_tx
                 .send_blocking(UiCommand::StartListener(lsock))
@@ -113,65 +207,25 @@ fn test_client_send_p2p() {
             wait(100);
             assert!(is_socket_bound_tcp(&lsock));
 
-            info!("Waiting for connection established event");
+            let (remote_sock, cid) = wait_for_connection(&ui_rx);
+            assert_ne!(remote_sock, lsock);
+
+            // Now that we have established a connection and gotten their identity, we need to do
+            // trust-on-first use. For this test, we just set the identity to trusted.
+            trust_contact(&cid, &ui_tx);
+            setup_chat(&cid, &ui_tx, &ui_rx);
+
+            let msg: SharedMessage =
+                Message::new("your parents are worried", Utc::now(), iden.id()).into();
+            send_message(&cid, msg, &ui_tx, &ui_rx);
+
+            info!("receiving message");
             assert_event!(
                 &ui_rx.recv_blocking().unwrap(),
-                UiEvent::SetKnownIdentities(_) // new identity from peer
+                UiEvent::SetKnownIdentities(_)
             );
-            let evt = ui_rx.recv_blocking().unwrap();
-            assert_event!(&evt, UiEvent::ConnectionEstablished(_, _));
-            if let UiEvent::ConnectionEstablished(remote_sock, cid) = evt {
-                assert_ne!(remote_sock, lsock);
 
-                // Now that we have established a connection and gotten their identity, we need to do
-                // trust-on-first use. For this test, we just set the identity to trusted.
-                ui_tx
-                    .send_blocking(UiCommand::TrustContact(
-                        cid.clone(),
-                        sremp_core::identity::Trust::Trusted,
-                    ))
-                    .unwrap();
-
-                info!("starting chat");
-                ui_tx
-                    .send_blocking(UiCommand::StartChat(cid.clone()))
-                    .unwrap();
-                assert_event!(&ui_rx.recv_blocking().unwrap(), UiEvent::LoadedChats(_));
-
-                info!("selecting chat");
-                ui_tx
-                    .send_blocking(UiCommand::SelectChat(cid.clone()))
-                    .unwrap();
-                assert_event!(&ui_rx.recv_blocking().unwrap(), UiEvent::OpenChat(_));
-
-                info!("sending message");
-                let msg: SharedMessage =
-                    Message::new("your parents are worried", Utc::now(), iden.id()).into();
-
-                ui_tx
-                    .send_blocking(UiCommand::SendMessage(cid.clone(), msg))
-                    .unwrap();
-                assert_event!(
-                    &ui_rx.recv_blocking().unwrap(),
-                    UiEvent::MessageSent(_, _, _)
-                );
-
-                info!("receiving message");
-                assert_event!(
-                    &ui_rx.recv_blocking().unwrap(),
-                    UiEvent::SetKnownIdentities(_)
-                );
-
-                ui_tx
-                    .send_blocking(UiCommand::Disconnect(remote_sock))
-                    .unwrap();
-                assert_event!(
-                    &ui_rx.recv_blocking().unwrap(),
-                    UiEvent::ConnectionLost(_, _)
-                );
-            } else {
-                unreachable!()
-            }
+            disconnect(remote_sock, &ui_tx, &ui_rx);
         }
         Fork::Child => {
             setup_logging(Some(" | C\n"));
@@ -179,76 +233,26 @@ fn test_client_send_p2p() {
             // status of a child process, and why should it. But that means that an error here is
             // not necessarily treated as a failed test!
 
-            let iden = UserIdentity::create("child").unwrap();
-
-            ui_tx
-                .send_blocking(UiCommand::SetIdentity(Some(iden.clone().into())))
-                .unwrap();
-            // NOTE: set identity currently causes two events, the direct response and that the working copy was updated
-            assert_event!(
-                &ui_rx.recv_blocking().unwrap(),
-                UiEvent::SetKnownIdentities(_)
-            );
-            assert_event!(&ui_rx.recv_blocking().unwrap(), UiEvent::IdentitySet(_));
+            let iden = setup_identity("child", &ui_tx, &ui_rx);
 
             ui_tx.send_blocking(UiCommand::Connect(lsock)).unwrap();
 
-            info!("Waiting for connection established event");
-            assert_event!(
-                &ui_rx.recv_blocking().unwrap(),
-                UiEvent::SetKnownIdentities(_) // new identity from peer
-            );
-            let evt = ui_rx.recv_blocking().unwrap();
-            assert_event!(&evt, UiEvent::ConnectionEstablished(_, _));
-            if let UiEvent::ConnectionEstablished(remote_sock, cid) = evt {
-                assert_eq!(remote_sock, lsock);
+            let (remote_sock, cid) = wait_for_connection(&ui_rx);
+            assert_eq!(remote_sock, lsock);
 
-                // Now that we have established a connection and gotten their identity, we need to do
-                // trust-on-first use. For this test, we just set the identity to trusted.
-                ui_tx
-                    .send_blocking(UiCommand::TrustContact(
-                        cid.clone(),
-                        sremp_core::identity::Trust::Trusted,
-                    ))
-                    .unwrap();
+            // Now that we have established a connection and gotten their identity, we need to do
+            // trust-on-first use. For this test, we just set the identity to trusted.
+            trust_contact(&cid, &ui_tx);
+            setup_chat(&cid, &ui_tx, &ui_rx);
 
-                info!("starting chat");
-                ui_tx
-                    .send_blocking(UiCommand::StartChat(cid.clone()))
-                    .unwrap();
-                assert_event!(&ui_rx.recv_blocking().unwrap(), UiEvent::LoadedChats(_));
+            info!("receiving message");
+            assert_event!(&ui_rx.recv_blocking().unwrap(), UiEvent::LoadedChats(_));
 
-                info!("selecting chat");
-                ui_tx
-                    .send_blocking(UiCommand::SelectChat(cid.clone()))
-                    .unwrap();
-                assert_event!(&ui_rx.recv_blocking().unwrap(), UiEvent::OpenChat(_));
+            let msg: SharedMessage =
+                Message::new("your parents are worried", Utc::now(), iden.id()).into();
+            send_message(&cid, msg, &ui_tx, &ui_rx);
 
-                info!("receiving message");
-                assert_event!(&ui_rx.recv_blocking().unwrap(), UiEvent::LoadedChats(_));
-
-                info!("sending message");
-                let msg: SharedMessage =
-                    Message::new("your parents are worried", Utc::now(), iden.id()).into();
-
-                ui_tx
-                    .send_blocking(UiCommand::SendMessage(cid.clone(), msg))
-                    .unwrap();
-                assert_event!(
-                    &ui_rx.recv_blocking().unwrap(),
-                    UiEvent::MessageSent(_, _, _)
-                );
-
-                ui_tx
-                    .send_blocking(UiCommand::Disconnect(remote_sock))
-                    .unwrap();
-                assert_event!(
-                    &ui_rx.recv_blocking().unwrap(),
-                    UiEvent::ConnectionLost(_, _)
-                );
-            } else {
-                panic!("No connection established?")
-            }
+            disconnect(remote_sock, &ui_tx, &ui_rx);
         }
     }
     wait(20);


### PR DESCRIPTION
vibecoded refactor, lets see if its any good

---

Reduce code duplication by extracting common test patterns into helper functions:
- setup_identity(): Set up user identity and wait for confirmation events
- trust_contact(): Establish trust with a contact
- setup_chat(): Start and select a chat
- send_message(): Send a message and wait for confirmation
- disconnect(): Disconnect and wait for confirmation
- wait_for_connection(): Wait for connection and get contact ID

This makes the Parent and Child test branches more concise and maintainable.